### PR TITLE
fix errant $j references.

### DIFF
--- a/www/js/jquery.gatracker.js
+++ b/www/js/jquery.gatracker.js
@@ -114,8 +114,8 @@
 				params = jQuery.extend(defaultParams, params);
 				
 				// setup tracking
-				$j("a").track(); // track external links, files, email addresses
-				$j("form").track({ event:"submit" }); // track external links
+				$("a").track(); // track external links, files, email addresses
+				$("form").track({ event:"submit" }); // track external links
 			});
 		};
 	})();


### PR DESCRIPTION
jQuery is being passed in and referenced as $, no need to go outside the scope of the function

Signed-off-by: Sean Coyne sean@n42designs.com
