### PR TITLE
a couple bug fixes for the webtop overview screen

### DIFF
--- a/webskin/types/webtopOverviewTabGA.cfm
+++ b/webskin/types/webtopOverviewTabGA.cfm
@@ -3,7 +3,7 @@
 
 <cfimport taglib="/farcry/core/tags/webskin" prefix="skin" />
 
-<cfset stSettings = application.fc.lib.ga.getSettings() />
+<cfset stSettings = application.fapi.getContentType("gaSetting").getSettings() />
 
 <cfif isdefined("url.getdata")>
 	
@@ -260,7 +260,7 @@
 </cfif>
 
 
-<cffunction name="arraymap" access="private" output="false" returntype="array" hint="Maps values to strings in another array">
+<!--- <cffunction name="arraymap" access="private" output="false" returntype="array" hint="Maps values to strings in another array">
 	<cfargument name="source" type="array" required="true" />
 	<cfargument name="map" type="array" required="true" />
 	<cfargument name="indexoffset" type="numeric" required="false" default="1" />
@@ -273,7 +273,7 @@
 	</cfloop>
 	
 	<cfreturn a />
-</cffunction>
+</cffunction> --->
 
 <cffunction name="arrayrenumber" access="private" output="false" returntype="array" hint="Renumbers values in array so that the specified value becomes 1 and values after that are incremented by 1. Also accounts for values that wrap back around to 1.">
 	<cfargument name="source" type="array" required="true" />


### PR DESCRIPTION
fixes incorrect getSettings() call and removes an unused function that uses a built-in function name